### PR TITLE
add DoWithStringResponse function and ExpectedResponseCode parameter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,15 +11,28 @@ linters:
 
 run:
   deadline: 10m
+  modules-download-mode: vendor
 
 issues:
+  exclude-use-default: false
   exclude-rules:
     - path: _test\.go
       linters:
         - dupl
         - goconst
         - gosec
+    - linters:
+        - govet
+      text: 'shadow: declaration of "err" shadows declaration'
+    - linters:
+        - golint
+      text: 'in another file for this package'
 
 linters-settings:
   gocyclo:
     min-complexity: 10
+  golint:
+    min-confidence: 0
+  govet:
+    check-shadowing: true
+

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ If the request could be made but the response status code was not `2xx` an error
 
 ## Example
 ```go
-import "github.com/fastbill/go-request/v2"
+import (
+    "net/http"
+    "github.com/fastbill/go-request/v2"
+)
 
 type Input struct {
 	RequestValue string `json:"requestValue"`
@@ -20,7 +23,7 @@ type Output struct {
 
 params := request.Params{
     URL:    "https://example.com",
-    Method: "POST",
+    Method: http.MethodPost,
     Headers: map[string]string{"my-header":"value", "another-header":"value2"},
     Body:   Input{RequestValue: "someValueIn"},
     Query: map[string]string{"key": "value"},
@@ -80,7 +83,7 @@ if err != nil {
     return err
 }
 
-req, err := http.NewRequest("POST", url, buf)
+req, err := http.NewRequest(http.MethodPost, url, buf)
 if err != nil {
     return err
 }

--- a/README.md
+++ b/README.md
@@ -24,10 +24,18 @@ params := request.Params{
     Headers: map[string]string{"my-header":"value", "another-header":"value2"},
     Body:   Input{RequestValue: "someValueIn"},
     Query: map[string]string{"key": "value"},
+    Timeout: 10 * time.Second,
+    ExpectedResponseCode: 201,
 }
 
 result := &Output{}
 err := request.Do(params, result)
+```
+All parameters besides the `URL` and the `Method` are optional and can be omitted.
+
+If you want to retrieve the response body as a string, e.g. for debugging or testing purposes, you can use `DoWithStringResponse` instead.
+```go
+result, err := request.DoWithStringResponse(params)
 ```
 
 ## Convenience wrappers
@@ -38,11 +46,11 @@ err := request.Post("http://example.com", Input{RequestValue: "someValueIn"}, re
 ```
 
 ## Defaults
-* All `2xx` response codes are treated as success, all other codes lead to an error being returned
+* All `2xx` response codes are treated as success, all other codes lead to an error being returned, if you want to check for a specific response code set `ExpectedResponseCode` in the parameters
 * If an HTTPError is returned it contains the response body as message if there was one
 * The request package takes care of closing the response body after sending the request
 * The http client does not follow redirects
-* The http client timeout is set to 30 seconds
+* The http client timeout is set to 30 seconds, use the `Timeout` parameter in case you want to define a different timeout for one of the requests
 * `Accept` and `Content-Type` request header are set to `application/json` and can be overwritten via the Headers parameter
 
 ## Streaming
@@ -98,7 +106,8 @@ if err != nil {
     return err
 }
 defer func() {
-    res.Body.Close()
+    err = res.Body.Close()
+    // handle err somehow
 }()
 
 result := &Output{}

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.1.4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=

--- a/request.go
+++ b/request.go
@@ -13,8 +13,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// client is the global client instance.
-var client *http.Client
+// cachedClient is the global client instance.
+var cachedClient *http.Client
 
 // defaultTimeout is the timeout applied if there is none provided.
 var defaultTimeout = 30 * time.Second
@@ -22,11 +22,11 @@ var defaultTimeout = 30 * time.Second
 // getCachedClient returns the client instance or creates it if it did not exist.
 // The client does not follow redirects and has a timeout of defaultTimeout.
 func getCachedClient() *http.Client {
-	if client == nil {
-		client = GetClient()
+	if cachedClient == nil {
+		cachedClient = GetClient()
 	}
 
-	return client
+	return cachedClient
 }
 
 // GetClient returns an http client that does not follow redirects and has a timeout of defaultTimeout.
@@ -58,7 +58,7 @@ func Do(params Params, responseBody interface{}) (returnErr error) {
 		return err
 	}
 
-	client := getClient(params.Timeout)
+	client := selectClient(params.Timeout)
 	res, err := client.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "failed to send request")
@@ -90,7 +90,7 @@ func DoWithStringResponse(params Params) (result string, returnErr error) {
 		return "", err
 	}
 
-	client := getClient(params.Timeout)
+	client := selectClient(params.Timeout)
 	res, err := client.Do(req)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to send request")
@@ -171,9 +171,9 @@ func convertToReader(body interface{}) (io.Reader, error) {
 	return buffer, nil
 }
 
-func getClient(timeout time.Duration) *http.Client {
+func selectClient(timeout time.Duration) *http.Client {
 	if timeout != 0 {
-		client = GetClient()
+		client := GetClient()
 		client.Timeout = timeout
 		return client
 	}

--- a/request.go
+++ b/request.go
@@ -144,12 +144,12 @@ func createRequest(params Params) (*http.Request, error) {
 
 // Get is a convience wrapper for "Do" to execute GET requests
 func Get(url string, responseBody interface{}) error {
-	return Do(Params{Method: "GET", URL: url}, responseBody)
+	return Do(Params{Method: http.MethodGet, URL: url}, responseBody)
 }
 
 // Post is a convience wrapper for "Do" to execute POST requests
 func Post(url string, requestBody interface{}, responseBody interface{}) error {
-	return Do(Params{Method: "POST", URL: url, Body: requestBody}, responseBody)
+	return Do(Params{Method: http.MethodPost, URL: url, Body: requestBody}, responseBody)
 }
 
 func convertToReader(body interface{}) (io.Reader, error) {

--- a/request_test.go
+++ b/request_test.go
@@ -41,12 +41,12 @@ func TestGetClient(t *testing.T) {
 		stdClient := http.Client{}
 		r, err := stdClient.Get(ts.URL)
 		assert.Error(t, err)
-		r.Body.Close()
+		assert.NoError(t, r.Body.Close())
 
 		client := GetClient()
 		res, err := client.Get(ts.URL)
 		assert.Equal(t, "/////", res.Header.Get("Location"))
-		res.Body.Close()
+		assert.NoError(t, res.Body.Close())
 		assert.NoError(t, err)
 	})
 }

--- a/request_test.go
+++ b/request_test.go
@@ -62,7 +62,7 @@ func TestDoSuccessful(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			body, _ := ioutil.ReadAll(r.Body)
 			assert.Equal(t, `{"requestValue":"someValueIn"}`+"\n", string(body))
-			assert.Equal(t, r.Method, "POST")
+			assert.Equal(t, r.Method, http.MethodPost)
 			w.WriteHeader(http.StatusCreated)
 			_, err := w.Write([]byte(`{"responseValue":"someValueOut"}`))
 			assert.NoError(t, err)
@@ -71,7 +71,7 @@ func TestDoSuccessful(t *testing.T) {
 
 		params := Params{
 			URL:                  ts.URL,
-			Method:               "POST",
+			Method:               http.MethodPost,
 			Body:                 Input{RequestValue: "someValueIn"},
 			ExpectedResponseCode: http.StatusCreated,
 		}
@@ -91,7 +91,7 @@ func TestDoSuccessful(t *testing.T) {
 
 		params := Params{
 			URL:    ts.URL + "?beenhere=before",
-			Method: "POST",
+			Method: http.MethodPost,
 			Query: map[string]string{
 				"testKey": "testValue",
 				"öä":      "%&/",
@@ -104,7 +104,7 @@ func TestDoSuccessful(t *testing.T) {
 
 	t.Run("no request body", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, r.Method, "POST")
+			assert.Equal(t, r.Method, http.MethodPost)
 			_, err := w.Write([]byte(`{"responseValue":"someValueOut"}`))
 			assert.NoError(t, err)
 		}))
@@ -112,7 +112,7 @@ func TestDoSuccessful(t *testing.T) {
 
 		params := Params{
 			URL:    ts.URL,
-			Method: "POST",
+			Method: http.MethodPost,
 		}
 
 		result := &Output{}
@@ -123,14 +123,14 @@ func TestDoSuccessful(t *testing.T) {
 
 	t.Run("no response body and no request body", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, r.Method, "GET")
+			assert.Equal(t, r.Method, http.MethodGet)
 			w.WriteHeader(http.StatusOK)
 		}))
 		defer ts.Close()
 
 		params := Params{
 			URL:    ts.URL,
-			Method: "GET",
+			Method: http.MethodGet,
 			Body:   nil,
 		}
 
@@ -147,7 +147,7 @@ func TestDoSuccessful(t *testing.T) {
 
 		params := Params{
 			URL:     ts.URL,
-			Method:  "GET",
+			Method:  http.MethodGet,
 			Body:    nil,
 			Timeout: 1 * time.Millisecond,
 		}
@@ -162,7 +162,7 @@ func TestDoSuccessful(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			body, _ := ioutil.ReadAll(r.Body)
 			assert.Equal(t, `{"requestValue":"someValueIn"}`, string(body))
-			assert.Equal(t, r.Method, "POST")
+			assert.Equal(t, r.Method, http.MethodPost)
 			_, err := w.Write([]byte(`{"responseValue":"someValueOut"}`))
 			assert.NoError(t, err)
 		}))
@@ -170,7 +170,7 @@ func TestDoSuccessful(t *testing.T) {
 
 		params := Params{
 			URL:    ts.URL,
-			Method: "POST",
+			Method: http.MethodPost,
 			Body:   strings.NewReader(`{"requestValue":"someValueIn"}`),
 		}
 
@@ -224,7 +224,7 @@ func TestDoHTTPErrors(t *testing.T) {
 
 		params := Params{
 			URL:    ts.URL,
-			Method: "GET",
+			Method: http.MethodGet,
 		}
 
 		err := Do(params, nil)
@@ -245,7 +245,7 @@ func TestDoHTTPErrors(t *testing.T) {
 
 		params := Params{
 			URL:    ts.URL,
-			Method: "GET",
+			Method: http.MethodGet,
 		}
 
 		err := Do(params, nil)
@@ -320,7 +320,7 @@ func TestDoWithStringResponse(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, r.Method, "GET")
+		assert.Equal(t, r.Method, http.MethodGet)
 		_, err := w.Write([]byte(`{"responseValue":"someValueOut"}`))
 		assert.NoError(t, err)
 	}))
@@ -336,7 +336,7 @@ func TestPost(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := ioutil.ReadAll(r.Body)
 		assert.Equal(t, `{"requestValue":"someValueIn"}`+"\n", string(body))
-		assert.Equal(t, r.Method, "POST")
+		assert.Equal(t, r.Method, http.MethodPost)
 		_, err := w.Write([]byte(`{"responseValue":"someValueOut"}`))
 		assert.NoError(t, err)
 	}))
@@ -361,7 +361,7 @@ func ExampleDo() {
 
 	params := Params{
 		URL:    ts.URL,
-		Method: "POST",
+		Method: http.MethodPost,
 		Body:   Input{RequestValue: "someValueIn"},
 	}
 
@@ -386,7 +386,7 @@ func ExampleDoWithStringResponse() {
 
 	params := Params{
 		URL:    ts.URL,
-		Method: "POST",
+		Method: http.MethodPost,
 	}
 
 	result, err := DoWithStringResponse(params)


### PR DESCRIPTION
To be able to use this package in more places two things have been added.
1. It is now possible to retrieve the response body just as a string via DoWithStringResponse.
2. ExpectedStatusCode can be provided in the parameters.

This MR also includes a fix for the linter config and it replaces the hard coded http method names.